### PR TITLE
Fix resource path lookup

### DIFF
--- a/uptime_widget.py
+++ b/uptime_widget.py
@@ -38,7 +38,8 @@ def resource_path(filename):
     """
     if hasattr(sys, '_MEIPASS'):
         return os.path.join(sys._MEIPASS, filename)
-    return os.path.join(os.path.abspath("."), filename)
+    base_path = os.path.dirname(os.path.abspath(__file__))
+    return os.path.join(base_path, filename)
 
 
 # === Localization ===


### PR DESCRIPTION
## Summary
- fix resource path helper to be relative to the script directory

## Testing
- `python -m py_compile uptime_widget.py`

------
https://chatgpt.com/codex/tasks/task_e_68411ae106248332a31d305811452a00